### PR TITLE
Adding skip_connect_on_init option

### DIFF
--- a/salt/proxy/netmiko_px.py
+++ b/salt/proxy/netmiko_px.py
@@ -244,7 +244,7 @@ def init(opts):
 
     netmiko_device['always_alive'] = netmiko_connection_args.pop('always_alive',
                                                                  opts.get('proxy_always_alive', True))
-    if not proxy_dict.get('skip_connect_on_init', False):
+    if not proxy_dict.get('skip_connect_on_init', True):
         try:
             connection = ConnectHandler(**netmiko_connection_args)
             netmiko_device['connection'] = connection


### PR DESCRIPTION
### What does this PR do?

Adding skip_connect_on_init optiom to netmiko proxy minion to avoid creating an connection during init.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
